### PR TITLE
filtering out temporary torrent files while scanning directories

### DIFF
--- a/application/tools/app_update_zip_list.php
+++ b/application/tools/app_update_zip_list.php
@@ -16,7 +16,7 @@ if ($handle = opendir('/application/flibusta')) {
 	$dbh->beginTransaction();
 
 	while (false !== ($entry = readdir($handle))) {   
-	        if (strpos($entry, "-") && strpos($entry, ".zip")) {
+		if (strpos($entry, "-") !== false && strpos($entry, ".zip") !== false && substr($entry, -9) !== ".zip.part") {
         		$dt = str_replace(".zip", "", $entry);
 		        $dt = str_replace("f.n.", "f.n-", $dt);
         		$dt = str_replace("f.fb2.", "f.n-", $dt);


### PR DESCRIPTION
### Описание изменений

В этом merge request добавлена функциональность для исключения временных файлов с расширением `.part` из процесса обработки файлов. Это изменение предотвратит возможные ошибки или нежелательное поведение, связанное с обработкой незавершенных файлов.

### Детали реализации

- Изменения внесены в функцию сканирования директории, где теперь с помощью регулярного выражения проверяется, не оканчивается ли имя файла на `.part`.
- Файлы, оканчивающиеся на `.part`, пропускаются и не подвергаются дальнейшей обработке.

### Причины изменений

я использую директорию с архивами для прямой загрузки торрент клиентом, незавешенные файлы мешали проводить сканирование.