### PR TITLE
Removed lib.libavtoraliase.sql.gz from download

### DIFF
--- a/getsql.sh
+++ b/getsql.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 wget --directory-prefix=FlibustaSQL -c -nc http://flibusta.is/sql/lib.libavtor.sql.gz
-wget --directory-prefix=FlibustaSQL -c -nc http://flibusta.is/sql/lib.libavtoraliase.sql.gz
 wget --directory-prefix=FlibustaSQL -c -nc http://flibusta.is/sql/lib.libtranslator.sql.gz
 wget --directory-prefix=FlibustaSQL -c -nc http://flibusta.is/sql/lib.libavtorname.sql.gz
 wget --directory-prefix=FlibustaSQL -c -nc http://flibusta.is/sql/lib.libbook.sql.gz


### PR DESCRIPTION
Removed downloading http://flibusta.is/sql/lib.libavtoraliase.sql.gz file as it doesn't exist anymore and showed 404 error

Удалено скачивание файла http://flibusta.is/sql/lib.libavtoraliase.sql.gz, так как он уже отсутствует на сайте и в списке https://flibusta.is/sql/