### PR TITLE
Fix docker build without buildkit

### DIFF
--- a/phpdocker/php-fpm/Dockerfile
+++ b/phpdocker/php-fpm/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:8.1-fpm-alpine
 
-ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 WORKDIR "/application"
 
 RUN apk --update add postgresql-client;\
   apk add python3;
-RUN install-php-extensions gd bz2 pdo_pgsql
+RUN chmod +x /usr/local/bin/install-php-extensions; install-php-extensions gd bz2 pdo_pgsql


### PR DESCRIPTION
Issue raised that after update php-fpm, building process if failed here: https://github.com/zlsl/flibusta/issues/22