### PR TITLE
Fixed trim function deprecation error in service index page

### DIFF
--- a/application/modules/service/index.php
+++ b/application/modules/service/index.php
@@ -6,7 +6,7 @@
 <div class='card-body'>
 <?php
 
-$status_import = (trim(shell_exec('ps aux|grep app_|grep -v grep')) !== '');
+$status_import = (trim(shell_exec('ps aux|grep app_|grep -v grep') ?? '') !== '');
 
 function get_ds($path){
 	$io = popen ( '/usr/bin/du -sk ' . $path, 'r' );


### PR DESCRIPTION
Also discussed in https://github.com/zlsl/flibusta/issues/22
`Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /application/modules/service/index.php on line 9`