### PR TITLE
Added zip php extension and fixed some errors with image covers

### DIFF
--- a/application/public/extract_cover.php
+++ b/application/public/extract_cover.php
@@ -9,12 +9,12 @@ function resizeCover($filename, $newwidth, $newheight){
 	$width = imagesx($i);
        	$height = imagesy($i);
     if($width > $height && $newheight < $height){
-        $newheight = $height / ($width / $newwidth);
+        $newheight = (int)round($height / ($width / $newwidth));
     } else if ($width < $height && $newwidth < $width) {
-        $newwidth = $width / ($height / $newheight);   
+        $newwidth = (int)round($width / ($height / $newheight));
     } else {
-        $newwidth = $width;
-        $newheight = $height;
+        $newwidth = (int)round($width);
+        $newheight = (int)round($height);
     }
     $thumb = imagecreatetruecolor($newwidth, $newheight);
     imagecopyresized($thumb, $i, 0, 0, 0, 0, $newwidth, $newheight, $width, $height);
@@ -102,7 +102,13 @@ $stmt->execute();
 $zip_name = $stmt->fetch()->filename;
 $zip = new ZipArchive(); 
 
-$filename = $dbh->query("SELECT filename FROM libfilename where BookId=$id")->fetch()->filename;
+$result = $dbh->query("SELECT filename FROM libfilename where BookId=$id")->fetch();
+
+if ($result) {
+    $filename = $result->filename;
+} else {
+    $filename = null;
+}
 if ($filename == '') {
 	$filename = trim("$id.$type");
 }

--- a/application/tools/app_import_sql.sh
+++ b/application/tools/app_import_sql.sh
@@ -2,6 +2,7 @@
 mkdir /application/sql/psql
 mkdir /application/cache/authors
 mkdir /application/cache/covers
+mkdir /application/cache/tmp
 
 echo "Распаковка sql.gz">/application/sql/status
 gzip -f -d /application/sql/*.gz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
             - './Flibusta.Net:/application/flibusta'
             - './FlibustaSQL:/application/sql'
             - './phpdocker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/conf.d/local-custom.ini'
+            - './phpdocker/php-fpm/php-fpm.conf:/usr/local/etc/php-fpm.d/zz-php-fpm.conf'
         environment:
             - FLIBUSTA_DBUSER=flibusta
             - FLUBUSTA_DBNAME=flibusta

--- a/phpdocker/php-fpm/Dockerfile
+++ b/phpdocker/php-fpm/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR "/application"
 
 RUN apk --update add postgresql-client;\
   apk add python3;
-RUN chmod +x /usr/local/bin/install-php-extensions; install-php-extensions gd bz2 pdo_pgsql
+RUN chmod +x /usr/local/bin/install-php-extensions; install-php-extensions gd bz2 pdo_pgsql zip

--- a/phpdocker/php-fpm/php-fpm.conf
+++ b/phpdocker/php-fpm/php-fpm.conf
@@ -1,0 +1,4 @@
+php_flag[display_errors] = off
+php_admin_flag[log_errors] = on
+[www]
+pm.max_children = 10


### PR DESCRIPTION
Without it we have next error on book view:

```
Fatal error: Uncaught Error: Class "ZipArchive" not found in /application/modules/book/index.php:45 Stack trace: #0 /application/renderer.php(125): include() #1 /application/public/index.php(148): include('/application/re...') #2 {main} thrown in /application/modules/book/index.php on line 45
```

Enabled error logging to investigate them.


and [fixed some issues with showing cover images](https://github.com/zlsl/flibusta/pull/27/commits/bd3e1b74c7b510ff453ddecdad8f5f2a505e432d)

such as:
```
NOTICE: PHP message: PHP Warning:  Attempt to read property "filename" on bool in /application/public/extract_cover.php on line 105
```

```
NOTICE: PHP message: PHP Deprecated:  Implicit conversion from float 232.25806451612902 to int loses precision in /application/public/extract_cover.php on line 19
NOTICE: PHP message: PHP Deprecated:  Implicit conversion from float 232.25806451612902 to int loses precision in /application/public/extract_cover.php on line 20
```

```
NOTICE: PHP message: PHP Warning:  file_put_contents(/application/cache/tmp/801120.tmp): Failed to open stream: No such file or directory in /application/public/extract_cover.php on line 143
```

```
WARNING: [pool www] server reached pm.max_children setting (5), consider raising it
```